### PR TITLE
Add techtree mod compatibility

### DIFF
--- a/GameData/Pebkac/Parts/LaunchEscape/LESTechNodePlacement.cfg
+++ b/GameData/Pebkac/Parts/LaunchEscape/LESTechNodePlacement.cfg
@@ -1,0 +1,11 @@
+//PEBKAC 1.25m L.E.S. relocation to the same Tech Node as the Mk1 v2 pod.
+@PART[pkLES_EscapeMk1v2]:LAST[Pebkac]
+{
+	@TechRequired = #$@PART[mk1pod_v2]/TechRequired$
+}
+
+//PEBKAC 2.5m L.E.S. relocation to the same Tech Node as the Mk1-3 pod.
+@PART[pkLES_mk2|pkLES_mk2_noBPC]:LAST[Pebkac]
+{
+	@TechRequired = #$@PART[mk1-3pod]/TechRequired$
+}


### PR DESCRIPTION
Ensures the LES will always be available at an appropriate time, regardless of where the command pods are in the tech tree.